### PR TITLE
Updates to make gem compatible with Rails 6

### DIFF
--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", ">= 4.2", "< 5.3"
+  spec.add_dependency             "activerecord", ">= 4.2", "< 6.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -79,10 +79,8 @@ module ActiveRecord
       # Although we're now setting the default timestamp column upstream, we'll still want to grab the default attributes here.
       # Doing so allows us to batch updates to non-standard columns along with the defaults in one query.
       # Note: timestamp_attributes_for_create_in_model gets frozen before returning in ActiveRecord version 6+
-      frozen_attributes = records.first.send(:timestamp_attributes_for_update_in_model)
-      attributes = frozen_attributes.dup
+      attributes = records.first.send(:timestamp_attributes_for_update_in_model).dup
       attributes << attr if attr
-      attributes.to_set
 
       if attributes.present?
         current_time = records.first.send(:current_time_from_proper_timezone)

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -43,9 +43,13 @@ module ActiveRecord
       end
 
       def add_record(record, *columns)
-        columns << nil if columns.empty? #if no arguments are passed, we will use nil to infer default column
+        # Inferring nil for touch calls with no column specified is creating duplicate DB calls for nested records
+        # Grab the default timestamp columns now as opposed to at write time
+        columns = record.send(:timestamp_attributes_for_update_in_model) if columns.blank?
+
         columns.each do |column|
-          @records[column] += [ record ] unless @already_updated_records[column].include?(record)
+          # Convert column explicitly to string here to keep types consistent
+          @records[column.to_s] += [ record ] unless @already_updated_records[column].include?(record)
         end
       end
 

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -49,7 +49,8 @@ module ActiveRecord
 
         columns.each do |column|
           # Convert column explicitly to string here to keep types consistent
-          @records[column.to_s] += [ record ] unless @already_updated_records[column].include?(record)
+          column = column.to_s
+          @records[column] += [ record ] unless @already_updated_records[column].include?(record)
         end
       end
 

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -49,7 +49,7 @@ module ActiveRecord
 
         columns.each do |column|
           # Convert column explicitly to string here to keep types consistent
-          column = column.to_s
+          column = column.to_s if column
           @records[column] += [ record ] unless @already_updated_records[column].include?(record)
         end
       end

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       def add_record(record, *columns)
         # Inferring nil for touch calls with no column specified is creating duplicate DB calls for nested records
         # Grab the default timestamp columns now as opposed to at write time
-        columns = record.send(:timestamp_attributes_for_update_in_model) if columns.blank?
+        columns = record.send(:timestamp_attributes_for_update_in_model) if columns.empty?
 
         columns.each do |column|
           # Convert column explicitly to string here to keep types consistent

--- a/lib/activerecord/delay_touching/version.rb
+++ b/lib/activerecord/delay_touching/version.rb
@@ -1,5 +1,5 @@
 module Activerecord
   module DelayTouching
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end


### PR DESCRIPTION
### Purpose
This PR upgrades the ActiveRecord Delay Touching gem to be compatible with Rails 6.0.0. In addition, it fixes a failing spec, and some core functionality that could cause records to be touched more times than intended

#### Bug Fix
Since roughly the release of Rails 5.1, it was possible for a record to be touched more times than intended. This issue would arise when:
- You call delay touching on a record with no key to touch specified
- You then call delay touching on the same record, with a key to touch specified

Due to the way records with no column specified were stored, the gem couldn't determine if the records had already been touched without a column explicitly specified. As a part of this PR, we've started grabbing the default timestamp columns upstream, in addition to assembling them downstream when touches are executed. This gives us a more accurate picture as to what columns need to be touched throughout execution, and helps to ensure we make as few round trips to the database as possible

### Changes
- Cloning frozen attributes for timestamp default columns to allow them to be modified when batching up writes
- Started grabbing timestamp default columns at the time of touch to minimize number of times a record gets re-written
- Normalizing incoming attribute names to ensure everything is stored consistently when collecting updates that need to be written

### Testing Done
- Ran (and fixed) specs using Rails 5.1, 5.2, and 6.0
- Tested in Rails console to ensure proper number of writes are executed
- Ran specs within sneakers application to ensure gem is fully compatible with Rails 5.2
- General CRUD testing locally